### PR TITLE
Add files and code to follow a user, uses default user numbers

### DIFF
--- a/db/dbPHPexample.php
+++ b/db/dbPHPexample.php
@@ -1,6 +1,7 @@
 <?php
 require_once('../db/DBConfig.php'); //Must have at the top of any file that needs db connection.
 require_once('../uploadBlock.php'); //Must have at the top of any page that will be able to post.
+require_once('../followBlock.php'); 
 ?>
 <html>
 	<head>
@@ -10,6 +11,13 @@ require_once('../uploadBlock.php'); //Must have at the top of any page that will
 		<?php
 			echo uploadBlock::insertForm();
 		?>
+		
+		<!-- new part-->
+		<!-- inserting follow block -->
+		<?php
+			echo followblock::follow();
+		?>
+		<!-- end new part-->
 		
 		<!-- viewing db contents -->
 		<?php
@@ -51,6 +59,23 @@ require_once('../uploadBlock.php'); //Must have at the top of any page that will
 			} else {
 				echo "0 results";
 			}
+			
+			// **NEW PART** Add followers output
+			//query 3
+			//fetch account followers
+			$sql = "SELECT u_id, follows FROM follow_tbl";
+			$result = $dbconn->query($sql);
+			
+			if ($result->num_rows > 0) {
+				// output data of each row
+				while($row = $result->fetch_assoc()) {
+					echo "User: " . $row["u_id"]. " - Follows: " . $row["follows"]. "</br>";
+				}
+			} else {
+				echo "0 results";
+			}
+			// **END NEW PART**
+			
 			//deallocate memory. 
 			//MUST BE DONE AFTER YOU'RE FINISHED WITH A DB CONNECTION
 			$dbconn = null;

--- a/db/followToDB.php
+++ b/db/followToDB.php
@@ -1,0 +1,24 @@
+<?php 
+require_once('../db/DBConfig.php'); 
+	//Author: Jasen Ratnam 40094237
+	
+	//TODO: Update to session values when available, update to new page after following
+	$u_id = 2; 
+	$redirect_path = '/BLU/db/dbPHPexample.php';
+	
+	// User ID of account you want to follow
+	// get this from user profile page when its done
+	$u_id2 = 3; 
+	
+	//Declare variables
+	$dbconn = null;
+	$sql = null;
+		
+	$sql = "INSERT INTO follow_tbl (u_id, follows) VALUES($u_id, $u_id2)";
+	
+	$dbconn = Database::getConnection();
+	$dbconn->query($sql);
+	$dbconn = null;		
+	
+	header('Location: '.$uri. $redirect_path);
+?>

--- a/followblock.php
+++ b/followblock.php
@@ -1,0 +1,12 @@
+<?php
+class followBlock{
+	private static $button = 
+		"<div id = \"follow_user\">
+			<form method=\"FOLLOW\" action=\"followToDB.php\" enctype=\"multipart/form-data\">
+				<input type=\"submit\" name=\"follow_user\" value=\"Follow\">
+			</form>
+		</div>";
+	
+	public static function follow(){ return self::$button; }
+}
+?>


### PR DESCRIPTION
**Description of Change**

- Added following feature, db example file has follow button that makes u_id=2 follow u_id=3. This should be changed to u_id of the person logged in and the u_id of the user profile you are watching, when user profile is done. Button currently in the db example should be placed somewhere on the user profile page and should give the u_id of the user. 

- Added static php function to insert the follow button in any future page (user profile page). (i.e. followBlock.php)

- updated dbPHPexample.php to be able to follow a user in it

**What will be affected**

- db/dbPHPexample.php

- new files created


**Link to GitHub Issue**
#71 #70 


**Good Practices Checklist**

- [x] Pull request fields filled (Title, Assignee, Reviewers, Labels, etc.)
- [x] Bug or issue is fixed
- [ ] No coding violations
- [ ] Build successful
- [x] Fix or feature has been tested and behaves as expected
